### PR TITLE
Play script now supports being called via symlink from outside folder

### DIFF
--- a/bin/play
+++ b/bin/play
@@ -1,5 +1,11 @@
 #!/usr/bin/env ruby
 
+# Change working directory so Bundler can find Gemfile
+THIS_FILE = File.symlink?(__FILE__) ? File.readlink(__FILE__) : __FILE__
+Dir.chdir File.dirname(THIS_FILE)
+require 'rubygems'
+require 'bundler/setup'
+
 require 'thor'
 require 'yaml'
 require 'json'


### PR DESCRIPTION
Added support for `play` to be symlinked into `$PATH`. Now Bundler finds its files, regardless how the script was called and what the current directory was.

Example:

```
ln -s /path/to/mocp_bunny_client/bin/play /usr/local/bin

play what
```
