### PR TITLE
Option not to print response from MusicClient#call and return instead

### DIFF
--- a/bin/play
+++ b/bin/play
@@ -9,19 +9,20 @@ CONFIG = YAML.load_file(File.expand_path("../config.yml", __dir__))
 
 class MusicControl < Thor
   no_commands do
-    def send_request(request)
-      conn = Bunny.new(:host => CONFIG["hostname"], :user => CONFIG["rabbit_user"], :password => CONFIG["rabbit_password"], 
+    def send_request(request, print = true)
+      conn = Bunny.new(:host => CONFIG["hostname"], :user => CONFIG["rabbit_user"], :password => CONFIG["rabbit_password"],
         :automatically_recover => false)
       conn.start
 
       ch = conn.create_channel
-      
+
       puts " [x] Sending #{request.to_s}"
       client = MusicClient.new(ch, "musicbox")
-      response = client.call(request)
+      response = client.call(request, print)
       #puts " [.] Response: #{response}"
       ch.close
       conn.close
+      response
     end
   end
 
@@ -51,7 +52,7 @@ class MusicControl < Thor
   def next
     send_request("next")
   end
-  
+
   desc "previous", "Play previous song."
   def previous
     send_request("previous")
@@ -84,7 +85,8 @@ class MusicControl < Thor
 
   desc "list", "Lists all songs in db."
   def list
-    send_request("list")
+    playlist = JSON.parse(send_request("list", false))
+    puts playlist
   end
 
   desc "start", "Start playing from the first item on the playlist."
@@ -93,5 +95,5 @@ class MusicControl < Thor
   end
 
 end
- 
+
 MusicControl.start(ARGV)

--- a/music_client.rb
+++ b/music_client.rb
@@ -30,7 +30,7 @@ class MusicClient
     end
   end
 
-  def call(request)
+  def call(request, print = true)
     self.call_id = SecureRandom.uuid
 
     @x.publish(request.to_s,
@@ -39,7 +39,7 @@ class MusicClient
       :reply_to       => @reply_queue.name)
 
     lock.synchronize{condition.wait(lock)}
-    puts response
+    puts response if print
     response
   end
 end


### PR DESCRIPTION
This adds optional argument `print` to both `MusicControl#send_request`  and `MusicClient#call` that can be used not to output response directly, but only return it for further manipulation.

Also this is used in `list` action to output readable playlist.
